### PR TITLE
Fix translate error on Tools section

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -192,7 +192,7 @@ app.controller("hashCalcCtrl", function($scope,$sce) {
 	}
 });
 */
-app.controller("ToolsCtrl", function($scope,$sce) {
+app.controller("ToolsCtrl", function($scope,$translate,$sce) {
 	$scope.wif = "";
 	$scope.privateKey = "";
 	$scope.publicKey = "";


### PR DESCRIPTION
There is an error on Tools section with empty value in the form
ReferenceError: $translate is not defined